### PR TITLE
Fix references in tutorial pdf

### DIFF
--- a/scripts/itrace.py
+++ b/scripts/itrace.py
@@ -84,10 +84,11 @@ class X86_64(Extractor):
     branchpattern = re.compile(r'^(?:repz\s+)?(j\w*|call|ret)q?')
     # e.g. 0x400(%rax,%rbx,8), 0x123(%rdx), etc.
     eapattern = re.compile(r'(-?(?:0x)?[0-9a-f]+)?'
-                            '\(''%([a-z0-9]+)'
-                                '(?:,%([a-z0-9]+),'
-                                '([1248]))?''\)'
-                            '(?:\s*,\s*%([a-z0-9]+))?')
+                           r'\(''%([a-z0-9]+)'
+                             r'(?:,%([a-z0-9]+),'
+                             r'([1248]))?'
+                           r'\)'
+                           r'(?:\s*,\s*%([a-z0-9]+))?')
 
     def printHeader(self, function):
         frame = gdb.newest_frame()
@@ -128,8 +129,9 @@ class ARM64(Extractor):
     branchpattern = re.compile(r'^(b\.\w+|bl?r?|cbn?z|ret)\b')
     # e.g. [x20,#40], [x20],#8, [x20,x21]
     eapattern = re.compile(r'\[(x[0-9]+|sp)'
-                            '(?:\s*,\s*(x[0-9]+|#-?(?:0x)?[0-9a-fA-F]+))?''\]'
-                            '(?:\s*,\s*#(-?(?:0x)?[0-9a-fA-F]+))?')
+                             r'(?:\s*,\s*(x[0-9]+|#-?(?:0x)?[0-9a-fA-F]+))?'
+                           r'\]'
+                           r'(?:\s*,\s*#(-?(?:0x)?[0-9a-fA-F]+))?')
 
     def printHeader(self, function):
         frame = gdb.newest_frame()
@@ -171,8 +173,9 @@ class ARM64(Extractor):
 class ARM32(Extractor):
     branchpattern = re.compile(r'^(b(?!f)\w*|cbn?z)\b')
     eapattern = re.compile(r'(?:\[([a-z]+[0-9]*)'
-                               '(?:\s*,\s*([a-z0-9]+|#-?(?:0x)?[0-9a-fA-F]+)|\s*:\d+)?''\]'
-                            '|(?:ld|st)m\w*\.?\w*\s+(\w+)!?,)')
+                             r'(?:\s*,\s*([a-z0-9]+|#-?(?:0x)?[0-9a-fA-F]+)|\s*:\d+)?'
+                           r'\]'
+                           r'|(?:ld|st)m\w*\.?\w*\s+(\w+)!?,)')
 
     def printHeader(self, function):
         frame = gdb.newest_frame()
@@ -379,7 +382,7 @@ def trace():
                     unit = 'g' if wordsize == 64 else 'w'
                     try :
                         value = gdb.execute("x/1x{0} 0x{1:x}".format(unit, ea["addr"]), False, True)
-                        value = re.match('0x[0-9a-fA-F]+\s*<?.*>?\s*:\s+(0x[0-9a-fA-F]+)', value).group(1)
+                        value = re.match(r'0x[0-9a-fA-F]+\s*<?.*>?\s*:\s+(0x[0-9a-fA-F]+)', value).group(1)
                     except gdb.MemoryError :
                         value = "'?'"
                     print("\t{0:48s}#! EA = L0x{1:x}; Value = {2}; PC = 0x{3:x}"


### PR DESCRIPTION
Sorry: In my previous PR the PDF had broken references. Fixed that now. 
Also, my pdflatex is not very happy about https://github.com/fmlab-iis/cryptoline/blob/16606923a0f08a0cad498c0cf716afc6fc17659f/doc/macro.tex#L219 because it is already defined. I did not change that yet.