### PR TITLE
Make save-mix respect disabled postconditions

### DIFF
--- a/main/std.ml
+++ b/main/std.ml
@@ -584,7 +584,7 @@ let anon file =
        List.fold_left
          (fun smtlibs s ->
            let vgen = Verify.Common.vgen_of_spec s in
-           let (_, smtlib) = Verify.Mix.smtlib_spec ~expn:false vgen s in
+           let (_, smtlib) = Verify.Mix.smtlib_spec ~expn:false ~rpost:!verify_rpost ~epost:!verify_epost vgen s in
            smtlib::smtlibs) [] ss in
      List.iteri output (List.rev smtlibs_rev)
   | Simulation ->

--- a/verify/mix.ml
+++ b/verify/mix.ml
@@ -155,17 +155,19 @@ let smtlib_var_ranges_mix vs =
 (* Convert a specification to SMTLIB. The output will use integer theory and
    bit-vector theory. Cuts and assertions are not allowed in the input
    specification. *)
-let smtlib_spec ?(expn=true) vgen s =
+let smtlib_spec ?(expn=true) ?(rpost=true) ?(epost=true) vgen s =
   let rs = rspec_of_spec s in
   let es = espec_of_spec s in
   (* === range === *)
   let rng_f = Smt.bexp_rbexp rs.rspre |> Qfbv.Common.smtlib2_of_bexp in
   let rng_p =  Smt.bexp_program rs.rsprog |> tmap Qfbv.Common.smtlib2_of_bexp in
   let rng_g =
-    let rng_g = Smt.bexp_rbexp (rbexp_prove_with_rands rs.rspost) in
-    if is_rspec_trivial rs
-    then smtlib_true
-    else Qfbv.Common.smtlib2_of_bexp rng_g in
+    if not rpost then smtlib_true
+    else 
+      let rng_g = Smt.bexp_rbexp (rbexp_prove_with_rands rs.rspost) in
+      if is_rspec_trivial rs
+      then smtlib_true
+      else Qfbv.Common.smtlib2_of_bexp rng_g in
   (* === algebra === *)
   let (vgen, zs) = Cas.bv2z_espec vgen es in
   (* pvs: bit-vector variables *)
@@ -175,11 +177,16 @@ let smtlib_spec ?(expn=true) vgen s =
   let alg_f = smtlib_ebexp_mix ~expn:expn is_pvar zs.ppre in
   let alg_p = tmap (smtlib_ebexp_mix ~expn:expn is_pvar) zs.pprog in
   let alg_g =
-    let alg_g = smtlib_ebexp_mix ~expn:expn is_pvar zs.ppost in
-    if is_espec_trivial es
-    then smtlib_true
-    else alg_g in
-  let alg_post_disj = List.rev_map (smtlib_eexp_mix ~expn:expn is_pvar) zs.pextra
+    if not epost then smtlib_true 
+    else 
+      let alg_g = smtlib_ebexp_mix ~expn:expn is_pvar zs.ppost in
+      if is_espec_trivial es
+      then smtlib_true
+      else alg_g in
+  let alg_post_disj = 
+    if not epost then []
+    else 
+    List.rev_map (smtlib_eexp_mix ~expn:expn is_pvar) zs.pextra
                       |> List.rev_map (fun e -> Smt.smtlib_eq e "0") in
   (* All variables *)
   let vars = Cas.vars_poly_spec zs in

--- a/verify/mix.mli
+++ b/verify/mix.mli
@@ -1,4 +1,4 @@
 
 open Ast.Cryptoline
 
-val smtlib_spec : ?expn:bool -> Cas.var_gen -> spec -> Cas.var_gen * string
+val smtlib_spec : ?expn:bool -> ?rpost:bool -> ?epost:bool -> Cas.var_gen -> spec -> Cas.var_gen * string


### PR DESCRIPTION
This patch makes `save-mix` respect the existing command-line flags
`-disable_rpost` and `-disable_epost` when generating mixed-theory SMT-LIB files.

Previously, `Verify.Mix.smtlib_spec` always included both range and algebraic
postconditions. This patch adds optional `rpost` and `epost` parameters to
`Verify.Mix.smtlib_spec` and forwards `verify_rpost` / `verify_epost`
from the command-line configuration.

Tested:
- `dune build`
- `-disable_rpost` with
  `examples/openssl/x25519/armv8/x25519_fe64_add.cl`
- `-disable_epost` with
  `examples/openssl/x25519/armv8/x25519_fe64_mul.cl`

Observed behavior:
- with `-disable_rpost`, the generated `save-mix` SMT-LIB output changes and
  the range postcondition is removed/disabled
- with `-disable_epost`, the generated postcondition changes from an
  algebraic condition like
  `(assert (not (and true (eqmodP1 ... ))))`
  to
  `(assert (not (and true true))))`