### PR TITLE
Fix ea pattern

### DIFF
--- a/scripts/cryptoline.py
+++ b/scripts/cryptoline.py
@@ -9,7 +9,7 @@ import clparse
 
 cryptoline_path = "cv"
 
-default_ea_pattern = r"L(0x\w+)"
+default_ea_pattern = r"L(?:([a-z][a-z0-9]*)_)?(0x\w+)"
 
 dontcare_variable = "_"
 
@@ -274,10 +274,20 @@ def compute_address(addr, offset, ea_pattern=default_ea_pattern):
     match = re.search(ea_pattern, addr)
     if match:
         base = match.group(1)
-        l = len(base) - 2
-        base = int(base, 0)
-        addr = base + offset
-        addr = ("L0x%0." + str(l) + "x") % addr
+        disp = match.group(2)
+        l = len(disp) - 2
+        # A CFA-relative label counts downwards from the frame address, so a
+        # higher address has a smaller displacement.
+        if base == "cfa":
+            disp = int(disp, 0) - offset
+            # Going past the CFA leaves the frame the label is relative to, and
+            # no displacement below it names that address.
+            if disp < 0:
+                raise Exception(f"The address {offset:+d} bytes from {addr} is above the CFA")
+        else:
+            disp = int(disp, 0) + offset
+        prefix = "L{}_".format(base) if base else "L"
+        addr = (prefix + "0x%0." + str(l) + "x") % disp
     return addr
 
 # Convert a Singular polynomial to an eexp.

--- a/scripts/to_zdsl.py
+++ b/scripts/to_zdsl.py
@@ -27,7 +27,7 @@ sort_rules = True
 
 counters = {}
 
-ea_pattern = "L0x[a-fA-f0-9]+"
+ea_pattern = r"L([a-fA-f0-9]{2,3}_)?0x[a-fA-f0-9]+"
 address_offset_group_pattern = r"(L0x\w+)\[\s*([\+|-])\s*(\d+)\s*\]"
 address_offset_pattern = r"L0x\w+\[\s*[\+|-]\s*\d+\s*\]"
 nop_instr = "nop"


### PR DESCRIPTION
#21 changed the format of effective address variables. This PR fixes the pattern in `to_zdsl.py` such that rules containing `$1ea` and similar apply again.